### PR TITLE
Add methods for accessing sets near a value in RangeSet and RangeMap

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -51,7 +51,8 @@ confidence=
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
 # TODO: Enable missing-docstring once it's not overwhelming
-disable=R,fixme,missing-docstring,no-member,unsupported-membership-test,unsubscriptable-object,unsupported-assignment-operation,not-an-iterable,too-many-lines,ungrouped-imports,import-error,bad-continuation
+# bad-whitespace and bad-continuation are disabled because we trust black to handle it
+disable=R,fixme,missing-docstring,no-member,unsupported-membership-test,unsubscriptable-object,unsupported-assignment-operation,not-an-iterable,too-many-lines,ungrouped-imports,import-error,bad-continuation,bad-whitespace
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/tests/test_range_map.py
+++ b/tests/test_range_map.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
 from immutablecollections import ImmutableSet
-from vistautils.range import ImmutableRangeMap, Range
+from vistautils.range import ImmutableRangeMap, Range, immutablerangemap
 
 
 class TestRangeMap(TestCase):
@@ -50,4 +50,132 @@ class TestRangeMap(TestCase):
         )
         self.assertEqual(
             ImmutableSet.empty(), range_map.get_enclosed_by(Range.closed(5, 5))
+        )
+
+    def test_overlapping_keys_banned(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "Some range keys are connected or overlapping. Overlapping keys "
+            "will never be supported. Support for connected keys is tracked in "
+            "https://github.com/isi-vista/vistautils/issues/37",
+        ):
+            (
+                ImmutableRangeMap.builder()
+                .put(Range.closed(0, 2), 0)
+                .put(Range.closed(1, 3), 1)
+                .build()
+            )
+
+    # this test should be remove after
+    # https://github.com/isi-vista/vistautils/issues/37 is fixed
+    def test_temporary_exception_on_connected_range_keys(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "Some range keys are connected or overlapping. Overlapping keys "
+            "will never be supported. Support for connected keys is tracked in "
+            "https://github.com/isi-vista/vistautils/issues/37",
+        ):
+            (
+                ImmutableRangeMap.builder()
+                .put(Range.open(0, 2), 0)
+                .put(Range.closed(2, 3), 1)
+                .build()
+            )
+
+    # adapted from corresponding tests in test_range_set
+    def test_get_maximal_containing_or_below(self):
+        range_map = immutablerangemap(
+            (
+                (Range.closed(-2, -1), 0),
+                (Range.closed_open(0, 2), 1),
+                # we don't do [0, 2), [2.1, 3] because they will coalesce
+                # ditto for (4, 5] and (5.1, 7)
+                (Range.closed(2.1, 3), 2),
+                (Range.open_closed(4, 5), 3),
+                (Range.open(5.1, 7), 4),
+            )
+        )
+
+        # probe value is in the middle of a set
+        # [2.1  ... *2.5* ... 3]
+        self.assertEqual(2, range_map.get_from_maximal_containing_or_below(2.5))
+        # probe value is at a closed upper limit
+        # [2.1 .... *3*]
+        self.assertEqual(2, range_map.get_from_maximal_containing_or_below(3.0))
+        # probe value is at a closed lower limit
+        # [*2.1* .... 3]
+        self.assertEqual(2, range_map.get_from_maximal_containing_or_below(2.1))
+        # probe value is at an open lower limit
+        # [2.1 ... 3], (*4* ... 5]
+        self.assertEqual(2, range_map.get_from_maximal_containing_or_below(4.0))
+        # probe value is at an open upper limit
+        # [0 ... *2.1*)
+        self.assertEqual(1, range_map.get_from_maximal_containing_or_below(2.0))
+        # probe value falls into a gap
+        # [-2, -1] ... *-0.5* ... [0, 2)
+        self.assertEqual(0, range_map.get_from_maximal_containing_or_below(-0.5))
+        # no range below
+        # *-3* .... [-2,-1]
+        self.assertIsNone(range_map.get_from_maximal_containing_or_below(-3.0))
+        # empty rangeset
+        self.assertIsNone(
+            immutablerangemap(
+                ((Range.closed(1.0, 2.0), 1),)
+            ).get_from_maximal_containing_or_below(0.0)
+        )
+        # lowest range has open lower bound
+        # (*1*,2)
+        self.assertIsNone(
+            immutablerangemap(
+                ((Range.open(1.0, 2.0), 1),)
+            ).get_from_maximal_containing_or_below(1.0)
+        )
+
+    # adapted from corresponding tests in test_range_set
+    def test_get_minimal_containing_or_above(self):
+        range_map = immutablerangemap(
+            (
+                (Range.closed(-2, -1), 0),
+                (Range.closed_open(0, 2), 1),
+                # we don't do [0, 2), [2.1, 3] because they will coalesce
+                # ditto for (4, 5] and (5.1, 7)
+                (Range.closed(2.1, 3), 2),
+                (Range.open_closed(4, 5), 3),
+                (Range.open(5.1, 7), 4),
+            )
+        )
+
+        # probe value is in the middle of a set
+        # [2.1  ... *2.5* ... 3]
+        self.assertEqual(2, range_map.get_from_minimal_containing_or_above(2.5))
+        # probe value is at a closed upper limit
+        # [2.1 .... *3*]
+        self.assertEqual(2, range_map.get_from_minimal_containing_or_above(3.0))
+        # probe value is at a closed lower limit
+        # [*2.1* .... 3]
+        self.assertEqual(2, range_map.get_from_minimal_containing_or_above(2.1))
+        # probe value is at an open lower limit
+        # [2 ... 3], (*4* ... 5]
+        self.assertEqual(3, range_map.get_from_minimal_containing_or_above(4.0))
+        # probe value is at an open upper limit
+        # [0 ... *2*) [2.1, 3.0]
+        self.assertEqual(2, range_map.get_from_minimal_containing_or_above(2.0))
+        # probe value falls into a gap
+        # [-2, -1] ... *-0.5* ... [0, 2)
+        self.assertEqual(1, range_map.get_from_minimal_containing_or_above(-0.5))
+        # no range above
+        # (5.1 ... 7) ... *8*
+        self.assertIsNone(range_map.get_from_minimal_containing_or_above(8))
+        # empty rangeset
+        self.assertIsNone(
+            immutablerangemap(
+                ((Range.closed(1.0, 2.0), 1),)
+            ).get_from_minimal_containing_or_above(3.0)
+        )
+        # higher range has open upper bound
+        # (1,*2*)
+        self.assertIsNone(
+            immutablerangemap(
+                ((Range.open(1.0, 2.0), 1),)
+            ).get_from_minimal_containing_or_above(2.0)
         )

--- a/tests/test_range_set.py
+++ b/tests/test_range_set.py
@@ -216,7 +216,7 @@ class TestRangeSet(TestCase):
             for query_2 in TestRangeSet.QUERY_RANGES:
                 self._test_intersects(RangeSet.create_mutable().add(query_1).add(query_2))
 
-    # forms the basis for corresponding tests in test_range_set
+    # forms the basis for corresponding tests in test_range_map
     def test_maximal_containing_or_below(self):
         range_set = RangeSet.create_mutable().add_all(
             (

--- a/tests/test_range_set.py
+++ b/tests/test_range_set.py
@@ -216,6 +216,136 @@ class TestRangeSet(TestCase):
             for query_2 in TestRangeSet.QUERY_RANGES:
                 self._test_intersects(RangeSet.create_mutable().add(query_1).add(query_2))
 
+    # forms the basis for corresponding tests in test_range_set
+    def test_maximal_containing_or_below(self):
+        range_set = RangeSet.create_mutable().add_all(
+            (
+                Range.closed(-2, -1),
+                Range.closed_open(0, 2),
+                # we don't do [0, 2), [2.1, 3] because they will coalesce
+                # ditto for (4, 5] and (5.1, 7)
+                Range.closed(2.1, 3),
+                Range.open_closed(4, 5),
+                Range.open(5.1, 7),
+            )
+        )
+
+        # probe value is in the middle of a set
+        # [2.1  ... *2.5* ... 3]
+        self.assertEqual(
+            Range.closed(2.1, 3.0), range_set.maximal_containing_or_below(2.5)
+        )
+        # probe value is at a closed upper limit
+        # [2.1 .... *3*]
+        self.assertEqual(
+            Range.closed(2.1, 3.0), range_set.maximal_containing_or_below(3.0)
+        )
+        # probe value is at a closed lower limit
+        # [*2.1* .... 3]
+        self.assertEqual(
+            Range.closed(2.1, 3.0), range_set.maximal_containing_or_below(2.1)
+        )
+        # probe value is at an open lower limit
+        # [2.1 ... 3], (*4* ... 5]
+        self.assertEqual(
+            Range.closed(2.1, 3.0), range_set.maximal_containing_or_below(4.0)
+        )
+        # probe value is at an open upper limit
+        # [0 ... *2.1*)
+        self.assertEqual(
+            Range.closed_open(0.0, 2.0), range_set.maximal_containing_or_below(2.0)
+        )
+        # probe value falls into a gap
+        # [-2, -1] ... *-0.5* ... [0, 2)
+        self.assertEqual(
+            Range.closed(-2.0, -1.0), range_set.maximal_containing_or_below(-0.5)
+        )
+        # no range below
+        # *-3* .... [-2,-1]
+        self.assertIsNone(range_set.maximal_containing_or_below(-3.0))
+        # empty rangeset
+        self.assertIsNone(
+            RangeSet.create_mutable()
+            .add(Range.closed(1.0, 2.0))
+            .maximal_containing_or_below(0.0)
+        )
+        # lowest range has open lower bound
+        # (*1*,2)
+        self.assertIsNone(
+            RangeSet.create_mutable()
+            .add(Range.open(1.0, 2.0))
+            .maximal_containing_or_below(1.0)
+        )
+
+    # forms the basis for corresponding tests in test_range_set
+    def test_minimal_containing_or_above(self):
+        range_set = RangeSet.create_mutable().add_all(
+            (
+                Range.closed(-2, -1),
+                Range.closed_open(0, 2),
+                # we don't do [0, 2), [2.1, 3] because they will coalesce
+                # ditto for (4, 5] and (5.1, 7)
+                Range.closed(2.1, 3),
+                Range.open_closed(4, 5),
+                Range.open(5.1, 7),
+            )
+        )
+
+        # probe value is in the middle of a set
+        # [2.1  ... *2.5* ... 3]
+        self.assertEqual(
+            Range.closed(2.1, 3.0), range_set.minimal_containing_or_above(2.5)
+        )
+        # probe value is at a closed upper limit
+        # [2.1 .... *3*]
+        self.assertEqual(
+            Range.closed(2.1, 3.0), range_set.minimal_containing_or_above(3.0)
+        )
+        # probe value is at a closed lower limit
+        # [*2.1* .... 3]
+        self.assertEqual(
+            Range.closed(2.1, 3.0), range_set.minimal_containing_or_above(2.1)
+        )
+        # probe value is at an open lower limit
+        # [2 ... 3], (*4* ... 5]
+        self.assertEqual(
+            Range.open_closed(4.0, 5.0), range_set.minimal_containing_or_above(4.0)
+        )
+        # probe value is at an open upper limit
+        # [0 ... *2*) [2.1, 3.0]
+        self.assertEqual(
+            Range.closed(2.1, 3.0), range_set.minimal_containing_or_above(2.0)
+        )
+        # probe value falls into a gap
+        # [-2, -1] ... *-0.5* ... [0, 2)
+        self.assertEqual(
+            Range.closed_open(0, 2), range_set.minimal_containing_or_above(-0.5)
+        )
+        # no range above
+        # (5.1 ... 7) ... *8*
+        self.assertIsNone(range_set.minimal_containing_or_above(8))
+        # empty rangeset
+        self.assertIsNone(
+            RangeSet.create_mutable()
+            .add(Range.closed(1.0, 2.0))
+            .minimal_containing_or_above(3.0)
+        )
+        # higher range has open upper bound
+        # (1,*2*)
+        self.assertIsNone(
+            RangeSet.create_mutable()
+            .add(Range.open(1.0, 2.0))
+            .minimal_containing_or_above(2.0)
+        )
+
+    def test_len(self):
+        self.assertEqual(0, len(RangeSet.create_mutable()))
+        self.assertEqual(1, len(RangeSet.create_mutable().add(Range.closed(1, 2))))
+        self.assertEqual(
+            2,
+            len(RangeSet.create_mutable().add(Range.closed(1, 2)).add(Range.open(3, 4))),
+        )
+
     # support methods
 
     def _pair_test(self, a: Range[int], b: Range[int]) -> None:


### PR DESCRIPTION
Adds maximal_containing_or_below and minimal_containing_or_above to
RangeSet. These allow querying for a value and getting the set
containing it, if any, or the next one in either direction.

Adds corresponding methods to RangeMap which work similarly,
but return the associated value.

Closes #40